### PR TITLE
Update upstream to 0.24.2 with two-factor support

### DIFF
--- a/files/brews/gh.rb
+++ b/files/brews/gh.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Gh < Formula
-  VERSION = "0.23.0"
+  VERSION = "0.24.2"
   ARCH = if MacOS.prefer_64_bit?
            "amd64"
          else


### PR DESCRIPTION
`gh` added support for two-factor auth in 0.24.2, see jingweno/gh#85 and https://github.com/jingweno/gh/commit/42e4d021cf5c5854920d386480bbbd9466a2c823

While you can get this update by running `brew upgrade [...]`, it's nice to have it by default!
